### PR TITLE
if there is binary string (like '\x00\x46 \xFE') in the source file, we ...

### DIFF
--- a/src/main/resources/org/yinwang/pysonar/python/dump_python.py
+++ b/src/main/resources/org/yinwang/pysonar/python/dump_python.py
@@ -19,7 +19,10 @@ class AstEncoder(JSONEncoder):
             if not is_python3:
                 for k in d:
                     if isinstance(d[k], str):
-                        d[k] = d[k].decode(enc)
+                        if k == 's':
+                          d[k] = lines[d['start']:d['end']]
+                        else:
+                          d[k] = d[k].decode(enc)
             d['type'] = o.__class__.__name__
             return d
         else:
@@ -27,7 +30,7 @@ class AstEncoder(JSONEncoder):
 
 
 enc = 'latin1'
-
+lines = ''
 
 def parse_dump(filename, output, end_mark):
     try:
@@ -48,7 +51,7 @@ def parse_dump(filename, output, end_mark):
 
 
 def parse_file(filename):
-    global enc
+    global enc, lines
     enc, enc_len = detect_encoding(filename)
     f = codecs.open(filename, 'r', enc)
     lines = f.read()


### PR DESCRIPTION
...can't directly decode with enc, the safest way is still to read from source string.

you can test it on this file:
https://github.com/django/django/blob/master/tests/backends/tests.py#L340

otherwise, this would cause pysonar try python3 because it failed to use python2, which later cause program die because it is not a python3 program. without this patch, you need disable python3 in order to proceed on some projects
