### PR TITLE
add unify to propagate type info backward

### DIFF
--- a/src/main/java/org/yinwang/pysonar/Analyzer.java
+++ b/src/main/java/org/yinwang/pysonar/Analyzer.java
@@ -322,7 +322,6 @@ public class Analyzer {
         return type;
     }
 
-
     @Nullable
     private Type parseAndResolve(String file) {
         loadingProgress.tick();
@@ -583,7 +582,7 @@ public class Analyzer {
 
             for (FunType cl : uncalledDup) {
                 progress.tick();
-                Call.apply(cl, null, null, null, null, null);
+                Call.apply(cl, null, null, null, null, null, null);
             }
         }
     }

--- a/src/main/java/org/yinwang/pysonar/ast/Alias.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Alias.java
@@ -28,6 +28,11 @@ public class Alias extends Node {
         return Type.UNKNOWN;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Assert.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Assert.java
@@ -31,6 +31,11 @@ public class Assert extends Node {
         return Type.CONT;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Assign.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Assign.java
@@ -31,6 +31,11 @@ public class Assign extends Node {
         return Type.CONT;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Attribute.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Attribute.java
@@ -91,6 +91,11 @@ public class Attribute extends Node {
         }
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     private Type getAttrType(@NotNull Type targetType) {
         Set<Binding> bs = targetType.table.lookupAttr(attr.id);

--- a/src/main/java/org/yinwang/pysonar/ast/BinOp.java
+++ b/src/main/java/org/yinwang/pysonar/ast/BinOp.java
@@ -38,6 +38,11 @@ public class BinOp extends Node {
         }
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Block.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Block.java
@@ -57,6 +57,11 @@ public class Block extends Node {
         return retType;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Break.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Break.java
@@ -24,4 +24,9 @@ public class Break extends Node {
     public Type transform(State s) {
         return Type.NONE;
     }
+
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
 }

--- a/src/main/java/org/yinwang/pysonar/ast/Bytes.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Bytes.java
@@ -22,6 +22,11 @@ public class Bytes extends Node {
         return Type.STR;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/ClassDef.java
+++ b/src/main/java/org/yinwang/pysonar/ast/ClassDef.java
@@ -63,6 +63,11 @@ public class ClassDef extends Node {
         return Type.CONT;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     private void addSpecialAttribute(@NotNull State s, String name, Type proptype) {
         Binding b = new Binding(name, Builtins.newTutUrl("classes.html"), proptype, Binding.Kind.ATTRIBUTE);

--- a/src/main/java/org/yinwang/pysonar/ast/Comprehension.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Comprehension.java
@@ -34,6 +34,11 @@ public class Comprehension extends Node {
         return transformExpr(target, s);
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Continue.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Continue.java
@@ -24,4 +24,9 @@ public class Continue extends Node {
     public Type transform(State s) {
         return Type.CONT;
     }
+
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
 }

--- a/src/main/java/org/yinwang/pysonar/ast/Delete.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Delete.java
@@ -31,6 +31,11 @@ public class Delete extends Node {
         return Type.CONT;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Dict.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Dict.java
@@ -31,6 +31,11 @@ public class Dict extends Node {
         return new DictType(keyType, valType);
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/DictComp.java
+++ b/src/main/java/org/yinwang/pysonar/ast/DictComp.java
@@ -39,6 +39,11 @@ public class DictComp extends Node {
         return new DictType(keyType, valueType);
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Dummy.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Dummy.java
@@ -22,4 +22,9 @@ public class Dummy extends Node {
         return Type.UNKNOWN;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 }

--- a/src/main/java/org/yinwang/pysonar/ast/Ellipsis.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Ellipsis.java
@@ -25,4 +25,9 @@ public class Ellipsis extends Node {
         return Type.NONE;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 }

--- a/src/main/java/org/yinwang/pysonar/ast/Exec.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Exec.java
@@ -36,6 +36,11 @@ public class Exec extends Node {
         return Type.CONT;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Expr.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Expr.java
@@ -29,6 +29,11 @@ public class Expr extends Node {
         return Type.CONT;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/ExtSlice.java
+++ b/src/main/java/org/yinwang/pysonar/ast/ExtSlice.java
@@ -29,6 +29,11 @@ public class ExtSlice extends Node {
         return new ListType();
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/For.java
+++ b/src/main/java/org/yinwang/pysonar/ast/For.java
@@ -45,6 +45,11 @@ public class For extends Node {
         return ret;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/FunctionDef.java
+++ b/src/main/java/org/yinwang/pysonar/ast/FunctionDef.java
@@ -84,6 +84,11 @@ public class FunctionDef extends Node {
         }
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     public String getArgumentExpr() {
         StringBuilder argExpr = new StringBuilder();

--- a/src/main/java/org/yinwang/pysonar/ast/GeneratorExp.java
+++ b/src/main/java/org/yinwang/pysonar/ast/GeneratorExp.java
@@ -34,6 +34,11 @@ public class GeneratorExp extends Node {
         return new ListType(transformExpr(elt, s));
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Global.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Global.java
@@ -26,6 +26,11 @@ public class Global extends Node {
         return Type.CONT;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Handler.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Handler.java
@@ -42,6 +42,11 @@ public class Handler extends Node {
         }
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/If.java
+++ b/src/main/java/org/yinwang/pysonar/ast/If.java
@@ -61,6 +61,11 @@ public class If extends Node {
         return UnionType.union(type1, type2);
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/IfExp.java
+++ b/src/main/java/org/yinwang/pysonar/ast/IfExp.java
@@ -41,6 +41,11 @@ public class IfExp extends Node {
         return UnionType.union(type1, type2);
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Import.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Import.java
@@ -35,6 +35,11 @@ public class Import extends Node {
         return Type.CONT;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/ImportFrom.java
+++ b/src/main/java/org/yinwang/pysonar/ast/ImportFrom.java
@@ -73,6 +73,11 @@ public class ImportFrom extends Node {
         return Type.CONT;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     public boolean isImportStar() {
         return names.size() == 1 && "*".equals(names.get(0).name.get(0).id);

--- a/src/main/java/org/yinwang/pysonar/ast/Index.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Index.java
@@ -23,6 +23,11 @@ public class Index extends Node {
         return transformExpr(value, s);
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Keyword.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Keyword.java
@@ -29,6 +29,11 @@ public class Keyword extends Node {
         return transformExpr(value, s);
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/ListComp.java
+++ b/src/main/java/org/yinwang/pysonar/ast/ListComp.java
@@ -35,6 +35,11 @@ public class ListComp extends Node {
         return new ListType(transformExpr(elt, s));
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Module.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Module.java
@@ -33,6 +33,11 @@ public class Module extends Node {
         return mt;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Name.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Name.java
@@ -58,6 +58,14 @@ public class Name extends Node {
         }
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+        Set<Binding> b = env.lookup(this.id);
+        for (Binding b1 : b) {
+            b1.addType(other);
+        }
+    }
+
 
     /**
      * Returns {@code true} if this name node is the {@code attr} child

--- a/src/main/java/org/yinwang/pysonar/ast/Node.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Node.java
@@ -122,6 +122,7 @@ public abstract class Node implements java.io.Serializable, Comparable<Object> {
     @NotNull
     protected abstract Type transform(State s);
 
+    protected abstract void unify(@NotNull Type other, @NotNull State env);
 
     protected void addWarning(String msg) {
         Analyzer.self.putProblem(this, msg);

--- a/src/main/java/org/yinwang/pysonar/ast/Pass.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Pass.java
@@ -18,6 +18,11 @@ public class Pass extends Node {
         return Type.CONT;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Print.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Print.java
@@ -34,6 +34,11 @@ public class Print extends Node {
         return Type.CONT;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/PyComplex.java
+++ b/src/main/java/org/yinwang/pysonar/ast/PyComplex.java
@@ -24,6 +24,11 @@ public class PyComplex extends Node {
         return Type.COMPLEX;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/PyFloat.java
+++ b/src/main/java/org/yinwang/pysonar/ast/PyFloat.java
@@ -29,6 +29,11 @@ public class PyFloat extends Node {
         return Type.FLOAT;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/PyInt.java
+++ b/src/main/java/org/yinwang/pysonar/ast/PyInt.java
@@ -58,6 +58,11 @@ public class PyInt extends Node {
         return Type.INT;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/PyList.java
+++ b/src/main/java/org/yinwang/pysonar/ast/PyList.java
@@ -33,6 +33,11 @@ public class PyList extends Sequence {
         return listType;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/PySet.java
+++ b/src/main/java/org/yinwang/pysonar/ast/PySet.java
@@ -34,6 +34,11 @@ public class PySet extends Sequence {
         return listType;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Raise.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Raise.java
@@ -36,6 +36,11 @@ public class Raise extends Node {
         return Type.CONT;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Repr.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Repr.java
@@ -26,6 +26,11 @@ public class Repr extends Node {
         return Type.STR;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Return.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Return.java
@@ -27,6 +27,11 @@ public class Return extends Node {
         }
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/SetComp.java
+++ b/src/main/java/org/yinwang/pysonar/ast/SetComp.java
@@ -30,6 +30,11 @@ public class SetComp extends Node {
         return new ListType(transformExpr(elt, s));
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Slice.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Slice.java
@@ -37,6 +37,11 @@ public class Slice extends Node {
         return new ListType();
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Starred.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Starred.java
@@ -23,6 +23,11 @@ public class Starred extends Node {
         return transformExpr(value, s);
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Str.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Str.java
@@ -22,6 +22,11 @@ public class Str extends Node {
         return Type.STR;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Subscript.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Subscript.java
@@ -39,6 +39,11 @@ public class Subscript extends Node {
         }
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     private Type getSubscript(@NotNull Type vt, @Nullable Type st, State s) {
@@ -82,7 +87,7 @@ public class Subscript extends Node {
                     addError("The type can't be sliced: " + vt);
                     return Type.UNKNOWN;
                 } else if (sliceFunc instanceof FunType) {
-                    return Call.apply((FunType) sliceFunc, null, null, null, null, this);
+                    return Call.apply((FunType) sliceFunc, null, null, null, null, this, null);
                 } else {
                     addError("The type's __getslice__ method is not a function: " + sliceFunc);
                     return Type.UNKNOWN;

--- a/src/main/java/org/yinwang/pysonar/ast/Try.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Try.java
@@ -58,6 +58,11 @@ public class Try extends Node {
         return new UnionType(tp1, tp2, tph, tpFinal);
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Tuple.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Tuple.java
@@ -25,6 +25,11 @@ public class Tuple extends Sequence {
         return t;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/UnaryOp.java
+++ b/src/main/java/org/yinwang/pysonar/ast/UnaryOp.java
@@ -25,6 +25,11 @@ public class UnaryOp extends Node {
         return transformExpr(operand, s);
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Url.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Url.java
@@ -25,6 +25,11 @@ public class Url extends Node {
         return Type.STR;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/While.java
+++ b/src/main/java/org/yinwang/pysonar/ast/While.java
@@ -39,6 +39,11 @@ public class While extends Node {
         return t;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/With.java
+++ b/src/main/java/org/yinwang/pysonar/ast/With.java
@@ -36,6 +36,11 @@ public class With extends Node {
         return transformExpr(body, s);
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/Withitem.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Withitem.java
@@ -39,4 +39,9 @@ public class Withitem extends Node {
         return Type.UNKNOWN;
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 }

--- a/src/main/java/org/yinwang/pysonar/ast/Yield.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Yield.java
@@ -28,6 +28,11 @@ public class Yield extends Node {
         }
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/ast/YieldFrom.java
+++ b/src/main/java/org/yinwang/pysonar/ast/YieldFrom.java
@@ -28,6 +28,11 @@ public class YieldFrom extends Node {
         }
     }
 
+    @Override
+    protected void unify(@NotNull Type other, @NotNull State env) {
+
+    }
+
 
     @NotNull
     @Override

--- a/src/main/java/org/yinwang/pysonar/types/InstanceType.java
+++ b/src/main/java/org/yinwang/pysonar/types/InstanceType.java
@@ -26,7 +26,7 @@ public class InstanceType extends Type {
 
         if (initFunc != null && initFunc instanceof FunType && ((FunType) initFunc).func != null) {
             ((FunType) initFunc).setSelfType(this);
-            Call.apply((FunType) initFunc, args, null, null, null, call);
+            Call.apply((FunType) initFunc, args, null, null, null, call, null);
             ((FunType) initFunc).setSelfType(null);
         }
     }


### PR DESCRIPTION
Hi, 

This commit suggest a new `Node` API called: 
````
void unify(Type target, State env)
````

The semantics of this API is that our engine will try its best to match current expression with the `target` type, if it could resolve more symbols, relevant entries will be updated in `env`. 

The API is motivated by the following 2 examples: 

## Binop
````python
def concat(a):
    return "hello, " + a
````
Pysonar2's abstract interpreter will assign "?" type to `a` and proceed. While with `unify`, we could check 2 operands of `Binop`, if one side is string(or int, float..), the other side should be the same type. So we could assign "str" type to a. 

## Call
````python
def concat(a):
    return "hello, " + a

concat("world")

def f(x):
    concat(x)
````
Since we know `concat` is of type "str -> str". When we use it in other places, the arguments to the function should also have "str" type. We can easily achieve this by implementing `unify` for `Call`. 

Any discussion is welcome. Thanks. 

