### PR TITLE
Remove redundant call to redirectError

### DIFF
--- a/src/main/java/org/yinwang/pysonar/Parser.java
+++ b/src/main/java/org/yinwang/pysonar/Parser.java
@@ -892,7 +892,6 @@ public class Parser {
         try {
             ProcessBuilder builder = new ProcessBuilder(pythonExe, "-i", jsonizer);
             builder.redirectErrorStream(true);
-            builder.redirectError(new File(parserLog));
             builder.redirectOutput(new File(parserLog));
             builder.environment().remove("PYTHONPATH");
             p = builder.start();


### PR DESCRIPTION
`redirectErrorStream(true)` would merge the stdout and stderr, there's no need to call `redirectError` to redirect the stderr to the same file that we are redirecting the stdout to.