### PR TITLE
when process parameters, "self" can't be ModuleType

### DIFF
--- a/src/main/java/org/yinwang/pysonar/visitor/TypeInferencer.java
+++ b/src/main/java/org/yinwang/pysonar/visitor/TypeInferencer.java
@@ -1098,7 +1098,7 @@ public class TypeInferencer implements Visitor1<Type, State> {
                 }
             } else {
                 // usual method
-                if (selfType != null) {
+                if (selfType != null && !(selfType instanceof ModuleType)) {
                     argTypes.add(selfType);
                 } else {
                     if (func.cls != null) {


### PR DESCRIPTION
eg:
=====a.py======
import b.c
b.c.gf("eeeeeeeeeee")

=====b\c.py=====
def gf(param):
    pass

Here b.c is package name, not class name