### PR TITLE
Replace StringBuffer with StringBuilder

### DIFF
--- a/src/main/java/org/yinwang/pysonar/$.java
+++ b/src/main/java/org/yinwang/pysonar/$.java
@@ -135,7 +135,7 @@ public class $ {
 
     @NotNull
     public static String arrayToString(@NotNull Collection<String> strings) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (String s : strings) {
             sb.append(s).append("\n");
         }


### PR DESCRIPTION
Replace `StringBuffer `with `StringBuilder ` to improve efficiency.