### PR TITLE
Fix parsing Boolean literal

### DIFF
--- a/src/main/java/org/yinwang/pysonar/Parser.java
+++ b/src/main/java/org/yinwang/pysonar/Parser.java
@@ -468,7 +468,7 @@ public class Parser {
             if (value == null) {
                 strVal = "None";
             } else if (value instanceof Boolean) {
-                strVal = ((Boolean) value) ? "true" : "false";
+                strVal = ((Boolean) value) ? "True" : "False";
             } else if (value instanceof String) {
                 strVal = (String) value;
             } else {


### PR DESCRIPTION
Currently, PySonar2 is unable to figure out the type of `a` in the following code:

```python
a = False
```

This PR should fix it.