### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ bases.
 To create high accuracy and quality index of Python, which is very dynamic language, PySonar2
 performs (costly) whole-project interprocedural analysis to infer types of variables, parameters and
 functions. Because of this, PySonar2 generally produces better index than Python IDEs (such as
-PyCharm etc.), while at the same time sacraficing real-time indexing abilities of IDEs.
+PyCharm etc.), while at the same time sacrificing real-time indexing abilities of IDEs.
 
 PySonar2 has been the underlying indexing engine for several large-scale code navigation services,
 such as Google's internal Code Search service, Sourcegraph.com and Insight.io (now part of

--- a/src/main/resources/org/yinwang/pysonar/python/dump_python.py
+++ b/src/main/resources/org/yinwang/pysonar/python/dump_python.py
@@ -112,7 +112,7 @@ def improve_ast(node, s):
 line_starts = []
 
 
-# build global table 'idxmap' for lineno <-> index oonversion
+# build global table 'idxmap' for lineno <-> index conversion
 def build_index_map(s):
     global line_starts
     idx = 0


### PR DESCRIPTION
There are small typos in:
- README.md
- src/main/resources/org/yinwang/pysonar/python/dump_python.py

Fixes:
- Should read `sacrificing` rather than `sacraficing`.
- Should read `conversion` rather than `oonversion`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md